### PR TITLE
Rework JSON Serializer to Throw Useful Exceptions

### DIFF
--- a/src/Elasticsearch/Common/Exceptions/Serializer/JsonDeserializationError.php
+++ b/src/Elasticsearch/Common/Exceptions/Serializer/JsonDeserializationError.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Elasticsearch\Common\Exceptions\Serializer;
+
+/**
+ * Thrown when there's an error unserializing a JSON string to a PHP array.
+ *
+ * @author   Christopher Davis <cdavis9999@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elasticsearch.org
+ */
+final class JsonDeserializationError extends JsonErrorException
+{
+    // noop
+}

--- a/src/Elasticsearch/Common/Exceptions/Serializer/JsonSerializationError.php
+++ b/src/Elasticsearch/Common/Exceptions/Serializer/JsonSerializationError.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Elasticsearch\Common\Exceptions\Serializer;
+
+/**
+ * Thrown when there's an error serialization a PHP object or array to a JSON
+ * string.
+ *
+ * @author   Christopher Davis <cdavis9999@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elasticsearch.org
+ */
+final class JsonSerializationError extends JsonErrorException
+{
+    // noop
+}

--- a/src/Elasticsearch/Serializers/AbstractJsonSerializer.php
+++ b/src/Elasticsearch/Serializers/AbstractJsonSerializer.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Elasticsearch\Serializers;
+
+use Elasticsearch\Common\Exceptions\Serializer\JsonSerializationError;
+use Elasticsearch\Common\Exceptions\Serializer\JsonDeserializationError;
+
+/**
+ * An abstract base class for serializers that go to/from JSON.
+ *
+ * @author   Christopher Davis <cdavis9999@gmail.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
+ * @link     http://elasticsearch.org
+ */
+abstract class AbstractJsonSerializer implements SerializerInterface
+{
+    /**
+     * Encode a php object or array to a JSON string
+     *
+     * @param   object|array $value
+     * @throws  JsonSerializationError if something goes wrong during encoding
+     * @return  string
+     */
+    protected static function jsonEncode($value)
+    {
+        $result = json_encode($value);
+
+        if (static::hasJsonError()) {
+            throw new JsonSerializationError(json_last_error(), $value, $result);
+        }
+
+        return '[]' === $result ? '{}' : $result;
+    }
+
+    /**
+     * Decode a JSON string to a PHP array.
+     *
+     * @param   string $json
+     * @throws  JsonDeserializationError if something goes wrong during decoding
+     * @return  array
+     */
+    protected static function jsonDecode($json)
+    {
+        $result = json_decode($json, true);
+
+        if (static::hasJsonError()) {
+            throw new JsonDeserializationError(json_last_error(), $json, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check to see if the last `json_{encode,decode}` call produced an error.
+     *
+     * @return  boolean
+     */
+    protected static function hasJsonError()
+    {
+        return json_last_error() !== JSON_ERROR_NONE;
+    }
+}

--- a/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/ArrayToJSONSerializer.php
@@ -16,10 +16,8 @@ namespace Elasticsearch\Serializers;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elasticsearch.org
  */
-class ArrayToJSONSerializer implements SerializerInterface
+class ArrayToJSONSerializer extends AbstractJsonSerializer
 {
-
-
     /**
      * Serialize assoc array into JSON string
      *
@@ -31,16 +29,9 @@ class ArrayToJSONSerializer implements SerializerInterface
     {
         if (is_string($data) === true) {
             return $data;
-        } else {
-            $data = json_encode($data);
-            if ($data === '[]') {
-                return '{}';
-            } else {
-                return $data;
-            }
         }
 
-
+        return $this->jsonEncode($data);
     }
 
 
@@ -54,7 +45,6 @@ class ArrayToJSONSerializer implements SerializerInterface
      */
     public function deserialize($data, $headers)
     {
-        return json_decode($data, true);
-
+        return $this->jsonDecode($data);
     }
 }

--- a/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
+++ b/src/Elasticsearch/Serializers/EverythingToJSONSerializer.php
@@ -15,9 +15,8 @@ namespace Elasticsearch\Serializers;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elasticsearch.org
  */
-class EverythingToJSONSerializer implements SerializerInterface
+class EverythingToJSONSerializer extends AbstractJsonSerializer
 {
-
     /**
      * Serialize assoc array into JSON string
      *
@@ -27,14 +26,8 @@ class EverythingToJSONSerializer implements SerializerInterface
      */
     public function serialize($data)
     {
-        $data = json_encode($data);
-        if ($data === '[]') {
-            return '{}';
-        } else {
-            return $data;
-        }
+        return $this->jsonEncode($data);
     }
-
 
     /**
      * Deserialize JSON into an assoc array
@@ -46,7 +39,6 @@ class EverythingToJSONSerializer implements SerializerInterface
      */
     public function deserialize($data, $headers)
     {
-        return json_decode($data, true);
-
+        return $this->jsonDecode($data);
     }
 }

--- a/src/Elasticsearch/Serializers/SmartSerializer.php
+++ b/src/Elasticsearch/Serializers/SmartSerializer.php
@@ -18,34 +18,8 @@ use Elasticsearch\Common\Exceptions\Serializer\JsonErrorException;
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache2
  * @link     http://elasticsearch.org
  */
-class SmartSerializer implements SerializerInterface
+class SmartSerializer extends ArrayToJSONSerializer
 {
-
-
-    /**
-     * Serialize assoc array into JSON string
-     *
-     * @param string|array $data Assoc array to encode into JSON
-     *
-     * @return string
-     */
-    public function serialize($data)
-    {
-        if (is_string($data) === true) {
-            return $data;
-        } else {
-            $data = json_encode($data);
-            if ($data === '[]') {
-                return '{}';
-            } else {
-                return $data;
-            }
-        }
-
-
-    }
-
-
     /**
      * Deserialize by introspecting content_type. Tries to deserialize JSON,
      * otherwise returns string
@@ -58,42 +32,10 @@ class SmartSerializer implements SerializerInterface
      */
     public function deserialize($data, $headers)
     {
-        if (isset($headers['content_type']) === true) {
-            if (strpos($headers['content_type'], 'json') !== false) {
-
-                return $this->decode($data);
-
-            } else {
-                //Not json, return as string
-                return $data;
-            }
-
-        } else {
-            //No content headers, assume json
-            return $this->decode($data);
+        if (isset($headers['content_type']) && strpos($headers['content_type'], 'json') === false) {
+            return $data;
         }
 
-
-    }
-
-    /**
-     * @todo For 2.0, remove the E_NOTICE check before raising the exception.
-     *
-     * @param $data
-     *
-     * @return array
-     * @throws JsonErrorException
-     */
-    private function decode($data)
-    {
-        $result = @json_decode($data, true);
-
-        // Throw exception only if E_NOTICE is on to maintain backwards-compatibility on systems that silently ignore E_NOTICEs.
-        if (json_last_error() !== JSON_ERROR_NONE && (error_reporting() & E_NOTICE) === E_NOTICE) {
-            $e = new JsonErrorException(json_last_error(), $data, $result);
-            throw $e;
-        }
-
-        return $result;
+        return $this->jsonDecode($data);
     }
 }

--- a/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/ArrayToJSONSerializerTest.php
@@ -9,7 +9,6 @@ namespace Elasticsearch\Tests\Serializers;
 
 use Elasticsearch\Serializers\ArrayToJSONSerializer;
 use PHPUnit_Framework_TestCase;
-use Mockery as m;
 
 /**
  * Class ArrayToJSONSerializerTest
@@ -17,11 +16,6 @@ use Mockery as m;
  */
 class ArrayToJSONSerializerTest extends PHPUnit_Framework_TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
-
     public function testSerializeArray()
     {
         $serializer = new ArrayToJSONSerializer();

--- a/tests/Elasticsearch/Tests/Serializers/SmartSerializerTest.php
+++ b/tests/Elasticsearch/Tests/Serializers/SmartSerializerTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * User: zach
+ * Date: 6/20/13
+ * Time: 9:07 AM
+ */
+
+namespace Elasticsearch\Tests\Serializers;
+
+use Elasticsearch\Serializers\SmartSerializer;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class SmartSerializerTest
+ * @package Elasticsearch\Tests\Serializers
+ */
+class SmartSerializerTest extends PHPUnit_Framework_TestCase
+{
+    private $serializer;
+
+    public function testDeserializeWithNonJsonContentTypeReturnsRawDataString()
+    {
+        $body = '<some-tag>content</some-tag>';
+
+        $result = $this->serializer->deserialize($body, array('content_type' => 'application/xml'));
+
+        $this->assertEquals($body, $result);
+    }
+
+    public function testDeserializeWithJsonContentTypeReturnsDecodedJson()
+    {
+        $result = $this->serializer->deserialize('{"one": "two"}', array('content_type' => 'application/json'));
+
+        $this->assertInternalType('array', $result);
+        $this->assertArrayHasKeY('one', $result);
+    }
+
+    public function testDeserializeWithoutContentTypeReturnsDecodedJson()
+    {
+        $result = $this->serializer->deserialize('{"one": "two"}', array());
+
+        $this->assertInternalType('array', $result);
+        $this->assertArrayHasKeY('one', $result);
+    }
+
+    protected function setUp()
+    {
+        $this->serializer = new SmartSerializer();
+    }
+}


### PR DESCRIPTION
Closes #175

Previously `SmartSerializer` was the only class that sometimes threw
exceptions when something went wrong during JSON deserialization. This
changes that so all serializers throw.

- `JsonSerializationError` is thrown when something goes wrong during
  `json_encode`
- `JsonDeserializationError` is thrown when something goes wrong during
  `json_decode`

Both are subclasses of `JsonErrorException`, so anyone already catching
that should be able to continue doing so.

There's a also a bit of restructuring here and some additional tests to
cover some more paths in the serializers.