### PR TITLE
allow pimple/pimple:~2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.3.9",
     "monolog/monolog": "~1.11",
-    "pimple/pimple": "~3.0",
+    "pimple/pimple": ">=2.0,<4.0",
     "guzzle/http": "~3.7",
     "psr/log": "~1.0",
     "ext-curl": "*"


### PR DESCRIPTION
Changed `pimple/pimple` dependency to allow `~2.0` also.

There are no code changes [between `pimple/pimple:~2.0` and `pimple/pimple:~3.0`](https://github.com/silexphp/Pimple/compare/v2.1.1...v3.0.0) so `~2.0` would be good enough for any project and it would remove a conflict with `silex/silex:~1.0`