### PR TITLE
Fix typo in 'metric' argument of Stats function in IndicesNamespace.php

### DIFF
--- a/src/Elasticsearch/Namespaces/IndicesNamespace.php
+++ b/src/Elasticsearch/Namespaces/IndicesNamespace.php
@@ -232,7 +232,7 @@ class IndicesNamespace extends AbstractNamespace
      */
     public function stats($params = array())
     {
-        $metric = $this->extractArgument($params, '$metric');
+        $metric = $this->extractArgument($params, 'metric');
 
         $index = $this->extractArgument($params, 'index');
 


### PR DESCRIPTION
Argument was not correctly extracted, so it was impossible to compose requests like `/_stats/indices` by setting `metric` param
Also related to 2.0 and master